### PR TITLE
Fix load settings in main process

### DIFF
--- a/bumpversion/main.py
+++ b/bumpversion/main.py
@@ -33,7 +33,7 @@ def echo(
 def _load_settings(ctx: click.Context, param: click.Option, value: str) -> str:
     """Load option defaults from config file."""
     # Use `construct` to skip pydantic validation.
-    settings = Settings.construct(config_file=value)  # type: ignore[call-arg]
+    settings = Settings(config_file=value)
     ctx.default_map = {
         "dry_run": settings.dry_run,
         "allow_dirty": settings.allow_dirty,

--- a/bumpversion/settings.py
+++ b/bumpversion/settings.py
@@ -36,9 +36,10 @@ def _config_file_settings(settings: "Settings") -> Dict[str, Any]:
     config_file = settings._config_file
     sections = ["bumpversion"]
     if config_file is None:
-        for config_file, _sections in CONFIG_FILES.items():
-            if os.path.isfile(config_file):
+        for _config_file, _sections in CONFIG_FILES.items():
+            if os.path.isfile(_config_file):
                 sections = _sections
+                config_file = _config_file
                 break
     if config_file:
         with open(config_file) as file:


### PR DESCRIPTION
Settings.construct does not call additional sources and config file is ignored. This causes problems with configuration that can be overrided with CLI options.